### PR TITLE
Refactor create record operation parameters

### DIFF
--- a/src/main/resources/salesforcerest-records/create.xml
+++ b/src/main/resources/salesforcerest-records/create.xml
@@ -16,24 +16,24 @@
    under the License.
 -->
 <template name="create" xmlns="http://ws.apache.org/ns/synapse">
-    <parameter name="sobject" description="The type of sobject"/>
-    <parameter name="sObjectName" description="The value of the field of a particular sObject"/>
+    <parameter name="sObjectName" description="The name of sObject"/>
+    <parameter name="sObject" description="The sObject with values to be created"/>
     <sequence>
-        <property name="uri.var.sobject" expression="$func:sobject"/>
         <property name="uri.var.sObjectName" expression="$func:sObjectName"/>
+        <property name="uri.var.sObject" expression="$func:sObject"/>
         <payloadFactory media-type="json">
             <format>
                 $1
             </format>
             <args>
-                <arg expression="get-property('uri.var.sObjectName')"/>
+                <arg expression="get-property('uri.var.sObject')"/>
             </args>
         </payloadFactory>
         <property name="Accept-Encoding" scope="transport" action="remove"/>
         <call>
             <endpoint>
                 <http method="post"
-                      uri-template="{uri.var.apiUrl}/services/data/{uri.var.apiVersion}/sobjects/{uri.var.sobject}"/>
+                      uri-template="{uri.var.apiUrl}/services/data/{uri.var.apiVersion}/sobjects/{uri.var.sObjectName}"/>
             </endpoint>
         </call>
     </sequence>

--- a/src/test/resources/artifacts/ESB/config/proxies/salesforcerest/create.xml
+++ b/src/test/resources/artifacts/ESB/config/proxies/salesforcerest/create.xml
@@ -44,8 +44,8 @@
             </salesforcerest.init>
             <log category="INFO" level="full" separator=","/>
             <salesforcerest.create>
-                <sobject>{$ctx:sobject}</sobject>
-                <sObjectName>{$ctx:sObjectName}</sObjectName>
+                <sObjectName>{$ctx:sobject}</sObjectName>
+                <sObject>{$ctx:sObjectName}</sObject>
             </salesforcerest.create>
             <send/>
         </inSequence>


### PR DESCRIPTION
Renamed parameters in create method since the terminology seems incorrect.

Refer : https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_basic_info.htm
