### PR TITLE
Add option to get a report using the report ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.salesforcerest</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <name>WSO2 Carbon - Mediation Library Connector For Salesforcerest</name>
     <url>http://wso2.org</url>
     <profiles>

--- a/src/main/resources/connector.xml
+++ b/src/main/resources/connector.xml
@@ -33,6 +33,7 @@
         <dependency component="salesforcerest-processrules"/>
         <dependency component="salesforcerest-attachment"/>
         <dependency component="salesforcerest-eventMonitoring"/>
+        <dependency component="salesforcerest-analytics"/>
         <description>wso2 connector for Salesforce REST API</description>
     </component>
     <icon>icon/icon-small.gif</icon>

--- a/src/main/resources/salesforcerest-analytics/component.xml
+++ b/src/main/resources/salesforcerest-analytics/component.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2022, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+
+   WSO2 LLC licenses this file to you under the Apache License,
+   Version 2.0 (the "License"); you may not use this file except
+   in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<component name="salesforcerest-analytics" type="synapse/template">
+    <subComponents>
+        <component name="getReport">
+            <file>getReport.xml</file>
+            <description>Returns the report for a specific report id.
+            </description>
+        </component>
+    </subComponents>
+</component>

--- a/src/main/resources/salesforcerest-analytics/getReport.xml
+++ b/src/main/resources/salesforcerest-analytics/getReport.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2022, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+
+   WSO2 LLC licenses this file to you under the Apache License,
+   Version 2.0 (the "License"); you may not use this file except
+   in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<template name="getReport" xmlns="http://ws.apache.org/ns/synapse">
+    <parameter name="reportId" description="The specific report ID to retrieve the report"/>
+    <sequence>
+        <property name="uri.var.callEndpointUri"
+                  expression="fn:concat($ctx:uri.var.apiUrl,'/services/data/',$ctx:uri.var.apiVersion,'/analytics/reports/',$func:reportId)"/>
+        <property name="httpMethod" value="get"/>
+        <salesforcerest.callWithRetry/>
+    </sequence>
+</template>

--- a/src/main/resources/salesforcerest-config/init.xml
+++ b/src/main/resources/salesforcerest-config/init.xml
@@ -59,7 +59,7 @@
                   expression="fn:concat(get-property('uri.var.tokenEndpointHostname'),'/services/oauth2/token')"/>
         <script language="js">
             <![CDATA[
-                var timeout = mc.getProperty("uri.var.timeout");
+                var timeout = mc.getProperty("timeout");
                 if (timeout == null || timeout == "") {
                     timeout = 3000;
                 }

--- a/src/main/resources/uischema/getReport.json
+++ b/src/main/resources/uischema/getReport.json
@@ -1,0 +1,49 @@
+{
+  "connectorName": "salesforcerest",
+  "operationName": "getReport",
+  "title": "Returns the report for a specific report id",
+  "help": "<h1>Get Reports</h1> <b>Retrieves the report of a specific report ID.</b><br><br><ul><li><a href=\"https://ei.docs.wso2.com/en/latest/micro-integrator/references/connectors/salesforce-rest-connector/sf-rest-connector-config/\"> More Help </a></li></ul>",
+  "elements": [
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "General",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "configRef",
+              "displayName": "Connection",
+              "inputType": "connection",
+              "allowedConnectionTypes": [
+                "init"
+              ],
+              "defaultValue": "",
+              "required": "true",
+              "helpTip": "Connection to be used"
+            }
+          },
+          {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "Basic",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "reportId",
+                    "displayName": "Report ID",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "The specific report ID to retrieve the report."
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
- Add the option to get a report using the report ID Fixes https://github.com/wso2-extensions/esb-connector-salesforcerest/issues/53
- Update timeout property Fixes https://github.com/wso2-extensions/esb-connector-salesforcerest/issues/54

## User stories
Added a new component called `getReport` to run a report immediately and return the latest summary data. More info at [Salesforce Reports](https://developer.salesforce.com/docs/atlas.en-us.234.0.api_analytics.meta/api_analytics/sforce_analytics_rest_api_getreportrundata.htm).

```xml
<salesforcerest.getReport configKey="SALESFORCEREST_CONNECTION_1">
    <reportId>{$ctx:reportID}</reportId>
</salesforcerest.getReport>
```
