### PR TITLE
Fix bug in soap and bulk functions

### DIFF
--- a/src/main/java/org/wso2/carbon/salesforce/connector/QueryMoreIterator.java
+++ b/src/main/java/org/wso2/carbon/salesforce/connector/QueryMoreIterator.java
@@ -60,6 +60,10 @@ public class QueryMoreIterator extends AbstractConnector {
                 String strQueryLocator = (String) synCtx
                         .getProperty("salesforce.query.queryLocator");
                 String strRecordSize = (String) synCtx.getProperty("salesforce.query.recordSize");
+                              
+                if (strQueryLocator == null || strRecordSize == null) {
+                    return;
+                }
 
                 String[] arrQueryLocator = strQueryLocator.split("-");
 
@@ -86,11 +90,10 @@ public class QueryMoreIterator extends AbstractConnector {
                     }
                 }
             } catch (NumberFormatException nfe) {
-                synLog.auditWarn("Saleforce adaptor - invalid value returned : " + nfe);
+                synLog.error("QueryMoreIterator - NumberFormatException: " + nfe.getMessage());
             } catch (Exception e) {
-                synLog.error("Saleforce adaptor - error generating the iterator payload : " + e);
+                synLog.error("QueryMoreIterator - Exception during processing: " + e.getMessage());
             }
-
         }
 
         if (synLog.isTraceOrDebugEnabled()) {

--- a/src/main/resources/bulkv2/createJob.xml
+++ b/src/main/resources/bulkv2/createJob.xml
@@ -22,7 +22,6 @@
     <parameter name="lineEnding" description="lineEnding"/>
     <parameter name="assignmentRuleId" description="assignmentRuleId"/>
     <parameter name="externalIdFieldName" description="externalIdFieldName"/>
-    <parameter name="contentType" description="contentType"/>
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
@@ -43,10 +42,7 @@
                 "object":     "${args.arg1}"        <#assign comma = true>
               </#if>
 
-              <#if args.arg7?? && args.arg7?has_content>
-                <#if comma>,</#if>
-                "contentType":"${args.arg7}"        <#assign comma = true>
-              </#if>
+              <#-- contentType is optional and defaults to CSV in Bulk API 2.0, so we omit it -->
 
               <#if args.arg3?? && args.arg3?has_content>
                 <#if comma>,</#if>
@@ -76,12 +72,11 @@
             ]]></format>
             <args>
                 <arg evaluator="xml" expression="$func:object"/>
-                <arg evaluator="xml" expression="$func:contentType"/>
+                <arg evaluator="xml" expression="$func:externalIdFieldName"/>
                 <arg evaluator="xml" expression="$func:operation"/>
                 <arg evaluator="xml" expression="$func:columnDelimiter"/>
                 <arg evaluator="xml" expression="$func:lineEnding"/>
                 <arg evaluator="xml" expression="$func:assignmentRuleId"/>
-                <arg evaluator="xml" expression="$func:externalIdFieldName"/>
             </args>
         </payloadFactory>
         <header name="Authorization" scope="transport"

--- a/src/main/resources/bulkv2/getFailedResults.xml
+++ b/src/main/resources/bulkv2/getFailedResults.xml
@@ -17,18 +17,31 @@
 -->
 <template xmlns="http://ws.apache.org/ns/synapse" name="getFailedResults">
     <parameter name="jobId" description="Job ID"/>
+    <parameter name="outputType" description="Output Type"/>
+    <parameter name="includeResultTo" description="Add Results To"/>
+    <parameter name="filePath" description="Output File Path"/>
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
+        <property name="outputType" expression="$func:outputType" />
+        <property name="includeResultTo" expression="$func:includeResultTo" />
+        <property name="filePath" expression="$func:filePath" />
+        <filter source="get-property('outputType')" regex="^$">
+            <then>
+                <property name="outputType" value="JSON" />
+            </then>
+        </filter>
         <class name="org.wso2.carbon.salesforce.connector.RestURLBuilder">
             <property name="resourcePath"
                       expression="fn:concat('/services/data/{$version}/jobs/ingest/',$func:jobId,'/failedResults')"/>
         </class>
         <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
+        <property name="messageType" expression="text/csv" scope="axis2" type="STRING"/>
+        <property name="ContentType" expression="text/csv" scope="axis2" type="STRING"/>
         <header name="Authorization" scope="transport"
                 expression="fn:concat('Bearer ', get-property('_OH_INTERNAL_ACCESS_TOKEN_'))"/>
-        <header name="Accept" scope="transport" value="application/json" action="set"/>
+        <header name="Accept" scope="transport" value="text/csv" action="set"/>
         <filter source="$ctx:salesforceRestBlocking" regex="true">
             <then>
                 <call blocking="true">
@@ -55,7 +68,11 @@
         </filter>
         <filter regex="200" source="$axis2:HTTP_SC">
             <then>
-                <class name="org.wso2.carbon.salesforce.connector.ProcessResults"/>
+                <class name="org.wso2.carbon.salesforce.connector.ProcessResults">
+                    <property name="outputType" expression="get-property('outputType')" />
+                    <property name="includeResultTo" expression="get-property('includeResultTo')" />
+                    <property name="filePath" expression="get-property('filePath')" />
+                </class>
             </then>
             <else/>
         </filter>

--- a/src/main/resources/bulkv2/getSuccessfulResults.xml
+++ b/src/main/resources/bulkv2/getSuccessfulResults.xml
@@ -24,16 +24,24 @@
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
+        <property name="outputType" expression="$func:outputType" />
+        <property name="includeResultTo" expression="$func:includeResultTo" />
+        <property name="filePath" expression="$func:filePath" />
+        <filter source="get-property('outputType')" regex="^$">
+            <then>
+                <property name="outputType" value="JSON" />
+            </then>
+        </filter>
         <class name="org.wso2.carbon.salesforce.connector.RestURLBuilder">
             <property name="resourcePath"
                       expression="fn:concat('/services/data/{$version}/jobs/ingest/',$func:jobId,'/successfulResults')"/>
         </class>
         <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
-        <property name="messageType" expression="application/json" scope="axis2" type="STRING"/>
-        <property name="ContentType" expression="application/json" scope="axis2" type="STRING"/>
+        <property name="messageType" expression="text/csv" scope="axis2" type="STRING"/>
+        <property name="ContentType" expression="text/csv" scope="axis2" type="STRING"/>
         <header name="Authorization" scope="transport"
                 expression="fn:concat('Bearer ', get-property('_OH_INTERNAL_ACCESS_TOKEN_'))"/>
-        <header name="Accept" scope="transport" value="application/json" action="set"/>
+        <header name="Accept" scope="transport" value="text/csv" action="set"/>
         <filter source="$ctx:salesforceRestBlocking" regex="true">
             <then>
                 <call blocking="true">
@@ -60,7 +68,11 @@
         </filter>
         <filter regex="200" source="$axis2:HTTP_SC">
             <then>
-                <class name="org.wso2.carbon.salesforce.connector.ProcessResults"/>
+                <class name="org.wso2.carbon.salesforce.connector.ProcessResults">
+                    <property name="outputType" expression="get-property('outputType')" />
+                    <property name="includeResultTo" expression="get-property('includeResultTo')" />
+                    <property name="filePath" expression="get-property('filePath')" />
+                </class>
             </then>
             <else/>
         </filter>

--- a/src/main/resources/bulkv2/getUnprocessedResults.xml
+++ b/src/main/resources/bulkv2/getUnprocessedResults.xml
@@ -17,18 +17,31 @@
 -->
 <template xmlns="http://ws.apache.org/ns/synapse" name="getUnprocessedResults">
     <parameter name="jobId" description="Job ID"/>
+    <parameter name="outputType" description="Output Type"/>
+    <parameter name="includeResultTo" description="Add Results To"/>
+    <parameter name="filePath" description="Output File Path"/>
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
+        <property name="outputType" expression="$func:outputType" />
+        <property name="includeResultTo" expression="$func:includeResultTo" />
+        <property name="filePath" expression="$func:filePath" />
+        <filter source="get-property('outputType')" regex="^$">
+            <then>
+                <property name="outputType" value="JSON" />
+            </then>
+        </filter>
         <class name="org.wso2.carbon.salesforce.connector.RestURLBuilder">
             <property name="resourcePath"
                       expression="fn:concat('/services/data/{$version}/jobs/ingest/',$func:jobId,'/unprocessedrecords')"/>
         </class>
         <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
+        <property name="messageType" expression="text/csv" scope="axis2" type="STRING"/>
+        <property name="ContentType" expression="text/csv" scope="axis2" type="STRING"/>
         <header name="Authorization" scope="transport"
                 expression="fn:concat('Bearer ', get-property('_OH_INTERNAL_ACCESS_TOKEN_'))"/>
-        <header name="Accept" scope="transport" value="application/json" action="set"/>
+        <header name="Accept" scope="transport" value="text/csv" action="set"/>
         <filter source="$ctx:salesforceRestBlocking" regex="true">
             <then>
                 <call blocking="true">
@@ -55,7 +68,11 @@
         </filter>
         <filter regex="200" source="$axis2:HTTP_SC">
             <then>
-                <class name="org.wso2.carbon.salesforce.connector.ProcessResults"/>
+                <class name="org.wso2.carbon.salesforce.connector.ProcessResults">
+                    <property name="outputType" expression="get-property('outputType')" />
+                    <property name="includeResultTo" expression="get-property('includeResultTo')" />
+                    <property name="filePath" expression="get-property('filePath')" />
+                </class>
             </then>
             <else/>
         </filter>

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -51,12 +51,6 @@
         <filter xpath="get-property('connectionType') = 'basicauth'">
             <then>
                 <class name="org.wso2.carbon.salesforce.connector.SalesforceSOAPLoginHandler"/>
-                <log level="custom" separator=", ">
-                    <property name="ConnectionName" expression="$func:connectionName"/>
-                    <property name="LoginType"      expression="$func:connectionType"/>
-                    <property name="SessionId"      expression="$ctx:salesforce.sessionId"/>
-                    <property name="ServiceUrl"     expression="$ctx:salesforce.serviceUrl"/>
-                </log>
             </then>
             <else>
                 <class name="org.wso2.carbon.salesforce.connector.SalesforceOAuthAccessTokenHandler"/>

--- a/src/main/resources/soap/soapConvertLead.xml
+++ b/src/main/resources/soap/soapConvertLead.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapDelete.xml
+++ b/src/main/resources/soap/soapDelete.xml
@@ -22,9 +22,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <class name="org.wso2.carbon.salesforce.connector.SetupCRUDParams"/>
         <property expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapDescribeGlobal.xml
+++ b/src/main/resources/soap/soapDescribeGlobal.xml
@@ -20,9 +20,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapDescribeSObject.xml
+++ b/src/main/resources/soap/soapDescribeSObject.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property expression="get-property('salesforce.serviceUrl')"
                   name="uri.var.salesforce.url"/>

--- a/src/main/resources/soap/soapDescribeSObjects.xml
+++ b/src/main/resources/soap/soapDescribeSObjects.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapEmptyRecycleBin.xml
+++ b/src/main/resources/soap/soapEmptyRecycleBin.xml
@@ -22,9 +22,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property expression="get-property('salesforce.serviceUrl')"
                   name="uri.var.salesforce.url"/>

--- a/src/main/resources/soap/soapFindDuplicates.xml
+++ b/src/main/resources/soap/soapFindDuplicates.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapFindDuplicatesByIds.xml
+++ b/src/main/resources/soap/soapFindDuplicatesByIds.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapGetDeleted.xml
+++ b/src/main/resources/soap/soapGetDeleted.xml
@@ -23,9 +23,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapGetServerTimestamp.xml
+++ b/src/main/resources/soap/soapGetServerTimestamp.xml
@@ -20,9 +20,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapGetUpdated.xml
+++ b/src/main/resources/soap/soapGetUpdated.xml
@@ -23,9 +23,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapGetUserInfo.xml
+++ b/src/main/resources/soap/soapGetUserInfo.xml
@@ -20,9 +20,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapLogout.xml
+++ b/src/main/resources/soap/soapLogout.xml
@@ -20,9 +20,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapMerge.xml
+++ b/src/main/resources/soap/soapMerge.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapQuery.xml
+++ b/src/main/resources/soap/soapQuery.xml
@@ -22,9 +22,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapQueryAll.xml
+++ b/src/main/resources/soap/soapQueryAll.xml
@@ -22,9 +22,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property expression="get-property('salesforce.serviceUrl')"
                   name="uri.var.salesforce.url"/>

--- a/src/main/resources/soap/soapQueryMore.xml
+++ b/src/main/resources/soap/soapQueryMore.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapResetPassword.xml
+++ b/src/main/resources/soap/soapResetPassword.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property expression="get-property('salesforce.serviceUrl')"
                   name="uri.var.salesforce.url"/>

--- a/src/main/resources/soap/soapRetrieve.xml
+++ b/src/main/resources/soap/soapRetrieve.xml
@@ -23,9 +23,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property expression="get-property('salesforce.serviceUrl')"
                   name="uri.var.salesforce.url"/>

--- a/src/main/resources/soap/soapSearch.xml
+++ b/src/main/resources/soap/soapSearch.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapSendEmail.xml
+++ b/src/main/resources/soap/soapSendEmail.xml
@@ -20,8 +20,6 @@
     <parameter name="sendEmail" description="XML representation of the email, as shown in the following example."/>
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
 
     <sequence>

--- a/src/main/resources/soap/soapSendEmailMessage.xml
+++ b/src/main/resources/soap/soapSendEmailMessage.xml
@@ -21,9 +21,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapSetPassword.xml
+++ b/src/main/resources/soap/soapSetPassword.xml
@@ -22,9 +22,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property expression="get-property('salesforce.serviceUrl')"
                   name="uri.var.salesforce.url"/>

--- a/src/main/resources/soap/soapUndelete.xml
+++ b/src/main/resources/soap/soapUndelete.xml
@@ -22,9 +22,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <property
                 expression="get-property('salesforce.serviceUrl')"

--- a/src/main/resources/soap/soapUpdate.xml
+++ b/src/main/resources/soap/soapUpdate.xml
@@ -23,9 +23,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <class name="org.wso2.carbon.salesforce.connector.SetupCRUDParams"/>
         <property

--- a/src/main/resources/soap/soapUpsert.xml
+++ b/src/main/resources/soap/soapUpsert.xml
@@ -24,9 +24,6 @@
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody"
                description="Replace the Message Body in Message Context with the response of the operation."/>
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody"
-               description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
         <class name="org.wso2.carbon.salesforce.connector.SetupCRUDParams"/>
         <property

--- a/src/main/resources/uischema/createJob.json
+++ b/src/main/resources/uischema/createJob.json
@@ -60,17 +60,6 @@
                 {
                   "type": "attribute",
                   "value": {
-                    "name": "contentType",
-                    "displayName": "Content Type",
-                    "inputType": "stringOrExpression",
-                    "defaultValue": "",
-                    "required": "true",
-                    "helpTip": "Format of the data file to upload. Allowed values: CSV or JSON."
-                  }
-                },
-                {
-                  "type": "attribute",
-                  "value": {
                     "name": "columnDelimiter",
                     "displayName": "Column Delimiter",
                     "inputType": "comboOrExpression",


### PR DESCRIPTION
## Purpose
Issues:
- Duplicate response variable parameters in soap files
- No setters in ProcessResults.java - bulk process results
- contentType in bulk v2 API is always CSV, only bulk v1 supports JSON (Docs refs [[1]](https://salesforce.stackexchange.com/questions/234791/does-salesforce-bulk-api-2-0-accept-json-as-the-contenttype) [[2]](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/bulk_api_2_0.htm) )